### PR TITLE
Issue-1_DCR-214 - Pretty output and debug mode for extra information in stderror

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ Total: 10, Dialing: 0, Established: 10, Closed: 0, Error: 0, NotInitiated: 0
 - more test coverage
 - "auto-incremental" mode; it opens connections at an specific rate until it fails or it times-out, giving you an idea of the max concurrency your service supports
 - distributed executions; several daemons may be able to collaborate to measure the capacity of an specific target
+- Docker image and OS packages for the most common distros
+- See also the issues in this Github repo!!

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## TL;DR
 
-Script to test the concurrent connections towards a server listening to a TCP port
+Script to test concurrent connections towards a server listening to a TCP port
 
 ## Description/Script steps
 
@@ -20,10 +20,14 @@ Script to test the concurrent connections towards a server listening to a TCP po
 Usage of ./tcpMaxConn:
   -connections int
         Number of connections you want to open (default 100)
+  -debug
+        Print debugging information to standard error
   -delay int
         Number of ms you want to sleep between each connection creation (default 10)
   -host string
         Host you want to open tcp connections against (default "localhost")
+  -interval int
+        Interval, in seconds, between updating connections status (default 1)
   -port int
         Port you want to open tcp connections against (default 9998)
 ```
@@ -31,42 +35,25 @@ Usage of ./tcpMaxConn:
 ## Example
 
 ```bash
-% ./tcpMaxConn -host ec2-54-229-56-140.eu-west-1.compute.amazonaws.com -port 8080 -connections 5 
-Initiating runner # 1
-         runner 1 is initiating a connection
-Runner 1 initated. Remaining: 4
-Initiating runner # 2
-         runner 2 is initiating a connection
-Runner 2 initated. Remaining: 3
-Initiating runner # 3
-         runner 3 is initiating a connection
-Runner 3 initated. Remaining: 2
-Initiating runner # 4
-         runner 4 is initiating a connection
-Runner 4 initated. Remaining: 1
-Initiating runner # 5
-         runner 5 is initiating a connection
-Runner 5 initated. Remaining: 0
-Waiting runners to finish
-         runner 2 established the connection
-         runner 1 established the connection
-         runner 4 established the connection
-         runner 3 established the connection
-         runner 5 established the connection
-         runner 2 got its connection closed
-         runner 1 got its connection closed
-         runner 4 got its connection closed
-         runner 5 got its connection closed
-         runner 3 got its connection closed
-
-Terminating Program
+% go run tcpMaxConn.go -host myhttpsamplehost.com -port 80 -connections 10 -delay 1000 
+Total: 10, Dialing: 0, Established: 0, Closed: 0, Error: 0, NotInitiated: 10
+Total: 10, Dialing: 0, Established: 1, Closed: 0, Error: 0, NotInitiated: 9
+Total: 10, Dialing: 0, Established: 2, Closed: 0, Error: 0, NotInitiated: 8
+Total: 10, Dialing: 0, Established: 3, Closed: 0, Error: 0, NotInitiated: 7
+Total: 10, Dialing: 0, Established: 4, Closed: 0, Error: 0, NotInitiated: 6
+Total: 10, Dialing: 0, Established: 5, Closed: 0, Error: 0, NotInitiated: 5
+Total: 10, Dialing: 0, Established: 6, Closed: 0, Error: 0, NotInitiated: 4
+Total: 10, Dialing: 1, Established: 7, Closed: 0, Error: 0, NotInitiated: 2
+Total: 10, Dialing: 1, Established: 8, Closed: 0, Error: 0, NotInitiated: 1
+Total: 10, Dialing: 1, Established: 9, Closed: 0, Error: 0, NotInitiated: 0
+Total: 10, Dialing: 0, Established: 10, Closed: 0, Error: 0, NotInitiated: 0
+Total: 10, Dialing: 0, Established: 10, Closed: 0, Error: 0, NotInitiated: 0
 ```
 
 ## TO-DO
 
-- Provide "live stats" of the number of threads and the status of each connection (using channels?)
 - Timeout configuration (max-duration?) so this can be reused for CI tests (if you cannot open X concurrent requests in 1 second, thats potentially a problem) 
 - Keepalive connections / reopen closed connections to keep this number of concurrent connections during an specific time (max-duration?)
-- Tests of this test ;)
+- more test coverage
 - "auto-incremental" mode; it opens connections at an specific rate until it fails or it times-out, giving you an idea of the max concurrency your service supports
 - distributed executions; several daemons may be able to collaborate to measure the capacity of an specific target

--- a/mtcpclient/reporting.go
+++ b/mtcpclient/reporting.go
@@ -1,0 +1,36 @@
+package mtcpclient
+
+import (
+	"github.com/dachad/check-max-tcp-connections/tcpclient"
+	"fmt"
+	"time"
+)
+
+func collectConnectionsStatus(connectionDescriptions []tcpclient.Connection, statusChannel <-chan tcpclient.Connection) {
+	for {
+		connectionStatus := <-statusChannel
+		connectionDescriptions[connectionStatus.Id] = connectionStatus
+
+	}
+}
+
+func reportConnectionsStatus(connectionDescriptions []tcpclient.Connection, intervalBetweenUpdates int) {
+	for {
+		fmt.Println(tcpclient.PrintGroupOfConnections(connectionDescriptions))
+		time.Sleep(time.Duration(intervalBetweenUpdates) * time.Second)
+	}
+}
+
+// startReportingLogic starts some goroutines to capture and report data from the tcpclient
+// routines. It initializes and returns the channel that will be used for these communications
+func StartReportingLogic(numberConnections int, rinterval int) chan tcpclient.Connection {
+	// A connection may report up to 3 messages: Dialing -> Established -> Closed
+	const maxMessagesWeMayGetPerConnection = 3
+	connStatusCh := make(chan tcpclient.Connection, numberConnections*maxMessagesWeMayGetPerConnection)
+	connStatusTracker := make([]tcpclient.Connection, numberConnections)
+
+	go reportConnectionsStatus(connStatusTracker, rinterval)
+	go collectConnectionsStatus(connStatusTracker, connStatusCh)
+
+	return connStatusCh
+}

--- a/mtcpclient/reporting.go
+++ b/mtcpclient/reporting.go
@@ -21,7 +21,7 @@ func reportConnectionsStatus(connectionDescriptions []tcpclient.Connection, inte
 	}
 }
 
-// startReportingLogic starts some goroutines to capture and report data from the tcpclient
+// StartReportingLogic starts some goroutines to capture and report data from the tcpclient
 // routines. It initializes and returns the channel that will be used for these communications
 func StartReportingLogic(numberConnections int, rinterval int) chan tcpclient.Connection {
 	// A connection may report up to 3 messages: Dialing -> Established -> Closed

--- a/mtcpclient/runner.go
+++ b/mtcpclient/runner.go
@@ -9,6 +9,10 @@ import (
 	"strconv"
 )
 
+// MultiTCPConnect tries to open us many TCP connections as numberConnections against
+// host:port, with a delay between them of delay (ms). You can supply a
+// debugOut to get debugging messages, while connStatusCh will be streaming
+// tcpclient.Connection descriptions on each status update of the connections
 func MultiTCPConnect(numberConnections int, delay int, host string, port int,
 		connStatusCh chan tcpclient.Connection, debugOut io.Writer) {
 	var wg sync.WaitGroup

--- a/mtcpclient/runner.go
+++ b/mtcpclient/runner.go
@@ -1,0 +1,25 @@
+package mtcpclient
+
+import (
+	"github.com/dachad/check-max-tcp-connections/tcpclient"
+	"sync"
+	"fmt"
+	"time"
+	"io"
+	"strconv"
+)
+
+func MultiTCPConnect(numberConnections int, delay int, host string, port int,
+		connStatusCh chan tcpclient.Connection, debugOut io.Writer) {
+	var wg sync.WaitGroup
+	wg.Add(numberConnections)
+	for runner := 0; runner < numberConnections; runner++ {
+		fmt.Fprintln(debugOut, "Initiating runner # " + strconv.Itoa(runner))
+		go tcpclient.TCPConnect(runner, host, port, &wg, debugOut, connStatusCh)
+		time.Sleep(time.Duration(delay) * time.Millisecond)
+		fmt.Fprintln(debugOut, "Runner " + strconv.Itoa(runner) +
+			" initated. Remaining: " + strconv.Itoa(numberConnections - runner))
+	}
+	fmt.Fprintln(debugOut, "Waiting runners to finish")
+	wg.Wait()
+}

--- a/tcpMaxConn.go
+++ b/tcpMaxConn.go
@@ -18,9 +18,9 @@ var debugOut io.Writer = ioutil.Discard
 func runTCPConnectionsInParallel(numberConnections int, delay int, host string, port int, rinterval int) {
 	const numberOfGoRoutinesToCollectAndReportStatus = 2
 	runtime.GOMAXPROCS(numberConnections + numberOfGoRoutinesToCollectAndReportStatus)
-	// A connection may report up to 3 messages: Dialing -> Established -> Connected
-	const MaxMessagesWeMayGetPerConnection = 3
-	connStatusCh := make(chan tcpclient.Connection, numberConnections*MaxMessagesWeMayGetPerConnection)
+	// A connection may report up to 3 messages: Dialing -> Established -> Closed
+	const maxMessagesWeMayGetPerConnection = 3
+	connStatusCh := make(chan tcpclient.Connection, numberConnections* maxMessagesWeMayGetPerConnection)
 	connStatusTracker := make([]tcpclient.Connection, numberConnections)
 
 	// moving these outside of runTcpCOnnectionsInParallel may have a lot of sense.. now this is

--- a/tcpclient/connection.go
+++ b/tcpclient/connection.go
@@ -1,0 +1,56 @@
+package tcpclient
+
+import "fmt"
+
+type Connection struct {
+	Id     int
+	status ConnectionStatus
+}
+
+type ConnectionStatus int
+
+var (
+	ConnectionNotInitiated ConnectionStatus = 0
+	ConnectionDialing      ConnectionStatus = 1
+	ConnectionEstablished  ConnectionStatus = 2
+	ConnectionClosed       ConnectionStatus = 3
+	ConnectionError        ConnectionStatus = 4
+)
+
+func (c Connection) String() string {
+	var status string
+	switch c.status {
+	case ConnectionNotInitiated:
+		status = "not initiated"
+	case ConnectionDialing:
+		status = "dialing"
+	case ConnectionEstablished:
+		status = "established"
+	case ConnectionClosed:
+		status = "closed"
+	case ConnectionError:
+		status = "error"
+	}
+	return fmt.Sprintf("Connection %d is %s", c.Id, status)
+}
+
+func PrintGroupOfConnections(c []Connection) string {
+	var nDialing, nEstablished, nClosed, nNotInitiated, nError, nTotal int = 0, 0, 0, 0, 0, 0
+	for _, item := range c {
+		switch item.status {
+		case ConnectionDialing:
+			nDialing += 1
+		case ConnectionEstablished:
+			nEstablished += 1
+		case ConnectionClosed:
+			nClosed += 1
+		case ConnectionError:
+			nError += 1
+		case ConnectionNotInitiated:
+			nNotInitiated += 1
+		}
+		nTotal += 1
+	}
+	return fmt.Sprintf("Total: %d, Dialing: %d, Established: %d, Closed: %d, Error: %d, NotInitiated: %d",
+		nTotal, nDialing, nEstablished, nClosed, nError, nNotInitiated)
+}

--- a/tcpclient/connectionsManagement.go
+++ b/tcpclient/connectionsManagement.go
@@ -18,7 +18,7 @@ func reportConnectionStatus(debugOut io.Writer, statusChannel chan<- Connection,
 	fmt.Fprintln(debugOut, "\t", connectionDescription)
 }
 
-// TCPconnect just opens a TCP connection against the target described by
+// TCPConnect just opens a TCP connection against the target described by
 // the host:port, and considers the id to report back status changes through the
 // status goChannel with descriptors matching the Connection struct supplied in this
 // same package.

--- a/tcpclient/connectionsManagement.go
+++ b/tcpclient/connectionsManagement.go
@@ -11,13 +11,18 @@ import (
 )
 
 // this can be an argument in the future
-var defaultDialTimeoutInSecs int = 10
+var defaultDialTimeoutInSecs = 10
 
 func reportConnectionStatus(debugOut io.Writer, statusChannel chan<- Connection, connectionDescription Connection) {
 	statusChannel <- connectionDescription
 	fmt.Fprintln(debugOut, "\t", connectionDescription)
 }
 
+// TCP connects just opens a TCP connection against the target described by
+// the host:port, and considers the id to report back status changes through the
+// status goChannel with descriptors matching the Connection struct supplied in this
+// same package.
+// It also needs an iowriter to print debugging information.
 func TCPConnect(id int, host string, port int, wg *sync.WaitGroup, debugOut io.Writer, statusChannel chan<- Connection) error {
 	connectionDescription := Connection{
 		Id:     id,

--- a/tcpclient/connectionsManagement.go
+++ b/tcpclient/connectionsManagement.go
@@ -7,20 +7,25 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"time"
 )
 
-func reportConnectionStatus(debugOut io.Writer, statusChannel chan<- Connection, connectionDescription Connection)  {
+// this can be an argument in the future
+var defaultDialTimeoutInSecs int = 10
+
+func reportConnectionStatus(debugOut io.Writer, statusChannel chan<- Connection, connectionDescription Connection) {
 	statusChannel <- connectionDescription
 	fmt.Fprintln(debugOut, "\t", connectionDescription)
 }
 
-func TcpConnect(id int, host string, port int, wg *sync.WaitGroup, debugOut io.Writer, statusChannel chan<- Connection) error {
+func TCPConnect(id int, host string, port int, wg *sync.WaitGroup, debugOut io.Writer, statusChannel chan<- Connection) error {
 	connectionDescription := Connection{
-		Id: id,
+		Id:     id,
 		status: ConnectionDialing,
 	}
 	reportConnectionStatus(debugOut, statusChannel, connectionDescription)
-	conn, err := net.Dial("tcp", host+":"+strconv.Itoa(port))
+	conn, err := net.DialTimeout("tcp", host+":"+strconv.Itoa(port),
+		time.Duration(defaultDialTimeoutInSecs)*time.Second)
 	if err != nil {
 		connectionDescription.status = ConnectionError
 		reportConnectionStatus(debugOut, statusChannel, connectionDescription)

--- a/tcpclient/connectionsManagement.go
+++ b/tcpclient/connectionsManagement.go
@@ -1,30 +1,46 @@
 package tcpclient
 
 import (
-	"sync"
-	"fmt"
-	"net"
 	"bufio"
+	"fmt"
+	"io"
+	"net"
 	"strconv"
+	"sync"
 )
 
-func TcpConnect(id int, host string, port int, wg *sync.WaitGroup) error {
-	fmt.Println("\t runner " + strconv.Itoa(id) + " is initiating a connection")
+func reportConnectionStatus(debugOut io.Writer, statusChannel chan<- Connection, connectionDescription Connection)  {
+	statusChannel <- connectionDescription
+	fmt.Fprintln(debugOut, "\t", connectionDescription)
+}
+
+func TcpConnect(id int, host string, port int, wg *sync.WaitGroup, debugOut io.Writer, statusChannel chan<- Connection) error {
+	connectionDescription := Connection{
+		Id: id,
+		status: ConnectionDialing,
+	}
+	reportConnectionStatus(debugOut, statusChannel, connectionDescription)
 	conn, err := net.Dial("tcp", host+":"+strconv.Itoa(port))
 	if err != nil {
-		fmt.Println(err)
+		connectionDescription.status = ConnectionError
+		reportConnectionStatus(debugOut, statusChannel, connectionDescription)
+		fmt.Fprintln(debugOut, "Connection", id, "was unable to open the connection. Error:")
+		fmt.Fprintln(debugOut, err)
 		wg.Done()
 		return err
 	}
-	fmt.Println("\t runner " + strconv.Itoa(id) + " established the connection")
+
+	connectionDescription.status = ConnectionEstablished
+	reportConnectionStatus(debugOut, statusChannel, connectionDescription)
 	connBuf := bufio.NewReader(conn)
 	for {
 		str, err := connBuf.ReadString('\n')
 		if len(str) > 0 {
-			fmt.Println(str)
+			fmt.Fprintln(debugOut, "Connection", id, "got", str)
 		}
 		if err != nil {
-			fmt.Println("\t runner " + strconv.Itoa(id) + " got its connection closed")
+			connectionDescription.status = ConnectionClosed
+			reportConnectionStatus(debugOut, statusChannel, connectionDescription)
 			wg.Done()
 			return err
 		}

--- a/tcpclient/connectionsManagement.go
+++ b/tcpclient/connectionsManagement.go
@@ -18,7 +18,7 @@ func reportConnectionStatus(debugOut io.Writer, statusChannel chan<- Connection,
 	fmt.Fprintln(debugOut, "\t", connectionDescription)
 }
 
-// TCP connects just opens a TCP connection against the target described by
+// TCPconnect just opens a TCP connection against the target described by
 // the host:port, and considers the id to report back status changes through the
 // status goChannel with descriptors matching the Connection struct supplied in this
 // same package.

--- a/tcpclient/connectionsManagement_test.go
+++ b/tcpclient/connectionsManagement_test.go
@@ -9,11 +9,13 @@ import (
 	"io/ioutil"
 )
 
+// We really need to refactor this test. We should verify connections do become established,
+// rather than just waiting for a second and finish
+// We should also test "failing" connections, and ensure their status is reported properly
 func TestTcpConnect(t *testing.T) {
 	var numberConnections = 2
 	var host = "127.0.0.1"
 	var port = 55555
-	var delay = 1
 
 	dispatcher := &tcpserver.Dispatcher{make(map[string]*tcpserver.Handler)}
 
@@ -32,16 +34,19 @@ func TestTcpConnect(t *testing.T) {
 	for runner := 1; runner <= numberConnections; runner++ {
 		t.Log("Initiating runner # ", strconv.Itoa(runner))
 		go TcpConnect(runner, host, port, &wg, ioutil.Discard, make(chan Connection, numberConnections))
-		time.Sleep(time.Duration(delay) * time.Millisecond)
 		t.Logf("Runner %s initated. Remaining: %s", strconv.Itoa(runner), strconv.Itoa(numberConnections-runner))
 	}
 
 	t.Log("Waiting runners to finish")
-	time.Sleep(time.Duration(delay) * time.Second)
+	time.Sleep(time.Second)
 
-	for runner := 1; runner <= numberConnections; runner++ {
-		t.Log("Closing runner #", strconv.Itoa(runner))
-		wg.Done()
-	}
+	// Marking wait groups as done after a second does not make sense...
+	// and in case one client finishes before this loop being executed (because of an error?)
+	// we will get an exception (panic: sync: negative WaitGroup counter [recovered])
+	
+	//for runner := 1; runner <= numberConnections; runner++ {
+	//	t.Log("Closing runner #", strconv.Itoa(runner))
+	//	wg.Done()
+	//}
 
 }

--- a/tcpclient/connectionsManagement_test.go
+++ b/tcpclient/connectionsManagement_test.go
@@ -33,7 +33,7 @@ func TestTcpConnect(t *testing.T) {
 
 	for runner := 1; runner <= numberConnections; runner++ {
 		t.Log("Initiating runner # ", strconv.Itoa(runner))
-		go TcpConnect(runner, host, port, &wg, ioutil.Discard, make(chan Connection, numberConnections))
+		go TCPConnect(runner, host, port, &wg, ioutil.Discard, make(chan Connection, numberConnections))
 		t.Logf("Runner %s initated. Remaining: %s", strconv.Itoa(runner), strconv.Itoa(numberConnections-runner))
 	}
 
@@ -43,7 +43,7 @@ func TestTcpConnect(t *testing.T) {
 	// Marking wait groups as done after a second does not make sense...
 	// and in case one client finishes before this loop being executed (because of an error?)
 	// we will get an exception (panic: sync: negative WaitGroup counter [recovered])
-	
+
 	//for runner := 1; runner <= numberConnections; runner++ {
 	//	t.Log("Closing runner #", strconv.Itoa(runner))
 	//	wg.Done()

--- a/tcpclient/connectionsManagement_test.go
+++ b/tcpclient/connectionsManagement_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 	"github.com/dachad/check-max-tcp-connections/tcpserver"
+	"io/ioutil"
 )
 
 func TestTcpConnect(t *testing.T) {
@@ -30,7 +31,7 @@ func TestTcpConnect(t *testing.T) {
 
 	for runner := 1; runner <= numberConnections; runner++ {
 		t.Log("Initiating runner # ", strconv.Itoa(runner))
-		go TcpConnect(runner, host, port, &wg)
+		go TcpConnect(runner, host, port, &wg, ioutil.Discard, make(chan Connection, numberConnections))
 		time.Sleep(time.Duration(delay) * time.Millisecond)
 		t.Logf("Runner %s initated. Remaining: %s", strconv.Itoa(runner), strconv.Itoa(numberConnections-runner))
 	}


### PR DESCRIPTION
Now we are no longer tracking in the standard output what we are doing... this is only staff for the new debug flag. And we use gochannels to communicate status of the connections, and an in memory slice to track the status of each. These connections do have an struct that describes their status, and allows pretty printing.

Some refactor could be possible / moving the reporting functions outside of the function raising execution threads, that could be also running in a different thread.